### PR TITLE
using shared library

### DIFF
--- a/jenkins/pipelines/pipe-1.groovy
+++ b/jenkins/pipelines/pipe-1.groovy
@@ -1,8 +1,5 @@
 stage "Load meow from github file."
-def meow = fileLoader.fromGit(
-    'src/com/puppet/util/Meow',
-    'git@github.com:puppetlabs/jenkins-global-workflowlib.git',
-    'master', null, '')
+def meow = new com.puppet.util.Meow()
 
 node {
      meow.experimental_repo_2_test()

--- a/jenkins/pipelines/pipe-1.groovy
+++ b/jenkins/pipelines/pipe-1.groovy
@@ -1,4 +1,4 @@
-stage "Load meow from github file."
+stage "Load meow from shared library"
 def meow = new com.puppet.util.Meow()
 
 node {


### PR DESCRIPTION
If you have pushed the jenkins-global-workflowlib to the jenkins master you shouldn't need to load from git again. My understanding of the plugin is that you would instanciate a new() object from the library if its in /src/com/puppet/util/ or directly create the clojure that will call your global function.
